### PR TITLE
fix: Corrigido problema com caixas de entrada dos objetivos

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
+    <runningDeviceTargetSelectedWithDropDown>
+      <Target>
+        <type value="RUNNING_DEVICE_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="C:\Users\gualm\.android\avd\Pixel_4_API_34.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </runningDeviceTargetSelectedWithDropDown>
     <targetSelectedWithDropDown>
       <Target>
         <type value="QUICK_BOOT_TARGET" />
@@ -12,8 +23,7 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-11-26T22:06:19.858557500Z" />
-    <multipleDevicesSelectedInDropDown value="true" />
+    <timeTargetWasSelectedWithDropDown value="2023-11-26T23:46:17.587244400Z" />
     <runningDeviceTargetsSelectedWithDialog>
       <Target>
         <type value="RUNNING_DEVICE_TARGET" />
@@ -21,15 +31,6 @@
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
             <value value="C:\Users\gualm\.android\avd\Pixel_4_API_34.avd" />
-          </Key>
-        </deviceKey>
-      </Target>
-      <Target>
-        <type value="RUNNING_DEVICE_TARGET" />
-        <deviceKey>
-          <Key>
-            <type value="SERIAL_NUMBER" />
-            <value value="52006190bca97547" />
           </Key>
         </deviceKey>
       </Target>

--- a/app/src/main/java/com/neuralnet/maisfinancas/ui/components/objetivos/ObjetivoTextField.kt
+++ b/app/src/main/java/com/neuralnet/maisfinancas/ui/components/objetivos/ObjetivoTextField.kt
@@ -32,10 +32,9 @@ fun ObjetivoTextField(
 
     TextField(
         value = valor,
-        onValueChange = {
-            val valorNumber = it.toBigDecimalOrNull() ?: BigDecimal.ZERO
-            isError = valorNumber > saldo || it.toDoubleOrNull() == null
-            onValueChange(it)
+        onValueChange = { value ->
+            value.toBigDecimalOrNull()?.let { isError = it > saldo }
+            onValueChange(value)
         },
         singleLine = true,
         prefix = { Text(stringResource(R.string.moeda)) },
@@ -48,7 +47,7 @@ fun ObjetivoTextField(
             if (errorMessage == FieldValidationError.NUMERO_INVALIDO) {
                 Text(text = stringResource(id = errorMessage.message))
             } else {
-                    Text(text = stringResource(R.string.disponivel, saldo.toReal()))
+                Text(text = stringResource(R.string.disponivel, saldo.toReal()))
             }
         }
     )
@@ -57,13 +56,13 @@ fun ObjetivoTextField(
 @Preview
 @Composable
 private fun ObjetivoTextFieldPreview() {
-    var valor by remember{ mutableStateOf("") }
+    var valor by remember { mutableStateOf("") }
 
     MaisFinancasTheme {
         ObjetivoTextField(
             valor = valor,
             saldo = BigDecimal.TEN,
-            onValueChange = { valor = it}
+            onValueChange = { valor = it }
         )
     }
 }

--- a/app/src/main/java/com/neuralnet/maisfinancas/ui/screens/objetivos/adicionar/AddObjetivoScreen.kt
+++ b/app/src/main/java/com/neuralnet/maisfinancas/ui/screens/objetivos/adicionar/AddObjetivoScreen.kt
@@ -5,11 +5,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Savings
 import androidx.compose.material3.Button
@@ -121,9 +124,10 @@ fun AddObjetivoScreen(
             modifier = Modifier
                 .padding(paddingValues)
                 .padding(8.dp)
+                .verticalScroll(rememberScrollState())
                 .fillMaxSize()
         ) {
-            Spacer(modifier = Modifier.weight(.25f))
+            Spacer(modifier = Modifier.height(32.dp))
 
             Surface(
                 shape = CircleShape,
@@ -139,7 +143,7 @@ fun AddObjetivoScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.weight(.2f))
+            Spacer(modifier = Modifier.height(32.dp))
 
             Text(
                 text = stringResource(R.string.nome_objetivo),
@@ -178,7 +182,7 @@ fun AddObjetivoScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            Spacer(modifier = Modifier.weight(.55f))
+            Spacer(modifier = Modifier.height(32.dp))
 
             Button(
                 onClick = onSaveClick,

--- a/app/src/main/java/com/neuralnet/maisfinancas/ui/screens/objetivos/detalhes/DetalhesObjetivoScreen.kt
+++ b/app/src/main/java/com/neuralnet/maisfinancas/ui/screens/objetivos/detalhes/DetalhesObjetivoScreen.kt
@@ -49,6 +49,8 @@ fun DetalhesObjetivoScreen(
     val detalhesObjetivoUiStateState = viewModel.detalhesObjetivoState.collectAsStateWithLifecycle()
     val updateObjetivoUiState = viewModel.updateObjetivoUiState.collectAsStateWithLifecycle()
 
+    val modoAtivo = viewModel.modoAtivo.collectAsStateWithLifecycle()
+
     val connectionState = viewModel.connectionState.collectAsStateWithLifecycle()
     val connectionMessage = connectionState.value.message?.let { stringResource(id = it) }
 
@@ -57,9 +59,9 @@ fun DetalhesObjetivoScreen(
         is ConnectionState.ServerUnavailable -> {
             ServidorIndisponivel(
                 onFinish = {
-                    if (updateObjetivoUiState.value.modoAtivo == ModoAtivo.GUARDAR) {
+                    if (modoAtivo.value == ModoAtivo.GUARDAR) {
                         viewModel.guardar()
-                    } else if (updateObjetivoUiState.value.modoAtivo == ModoAtivo.RESGATAR) {
+                    } else if (modoAtivo.value == ModoAtivo.RESGATAR) {
                         viewModel.resgatar()
                     }
                 }
@@ -70,6 +72,8 @@ fun DetalhesObjetivoScreen(
             DetalhesObjetivoScreen(
                 detalhesObjetivoUiState = detalhesObjetivoUiStateState.value,
                 updateObjetivoUiState = updateObjetivoUiState.value,
+                modoAtivo = modoAtivo.value,
+                onAlternarModoAtivo = viewModel::alternarModoAtivo,
                 onUiStateChange = viewModel::updateObjetivoState,
                 onNavigateUp = onNavigateUp,
                 onResgatarClick = {
@@ -83,6 +87,7 @@ fun DetalhesObjetivoScreen(
                     }
                 },
                 connectionMessage = connectionMessage,
+                onResetState = viewModel::resetObjetivoState,
             )
         }
     }
@@ -92,11 +97,14 @@ fun DetalhesObjetivoScreen(
 fun DetalhesObjetivoScreen(
     detalhesObjetivoUiState: DetalhesObjetivoUiState,
     updateObjetivoUiState: UpdateObjetivoUiState,
+    modoAtivo: ModoAtivo,
+    onAlternarModoAtivo: (ModoAtivo) -> Unit,
     onUiStateChange: (UpdateObjetivoUiState) -> Unit,
     onNavigateUp: () -> Unit,
     onResgatarClick: () -> Unit,
     onGuardarClick: () -> Unit,
     connectionMessage: String? = null,
+    onResetState: () -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -161,10 +169,10 @@ fun DetalhesObjetivoScreen(
                     .padding(vertical = 24.dp)
             )
 
-            if (updateObjetivoUiState.modoAtivo != ModoAtivo.INVISIBLE) {
+            if (modoAtivo != ModoAtivo.INVISIBLE) {
                 AlertDialog(
                     onDismissRequest = {
-                        onUiStateChange(updateObjetivoUiState.copy(modoAtivo = ModoAtivo.INVISIBLE))
+                        onAlternarModoAtivo(ModoAtivo.INVISIBLE)
                     },
                     title = {
                         Text(
@@ -185,20 +193,14 @@ fun DetalhesObjetivoScreen(
                     },
                     dismissButton = {
                         TextButton(
-                            onClick = {
-                                onUiStateChange(
-                                    updateObjetivoUiState.copy(
-                                        modoAtivo = ModoAtivo.INVISIBLE,
-                                        valor = "",
-                                    )
-                                )
-                            }
+                            onClick = onResetState
+
                         ) {
                             Text(text = stringResource(id = R.string.cancelar))
                         }
                     },
                     confirmButton = {
-                        if (updateObjetivoUiState.modoAtivo == ModoAtivo.GUARDAR) {
+                        if (modoAtivo == ModoAtivo.GUARDAR) {
                             TextButton(
                                 onClick = onGuardarClick,
                                 enabled = updateObjetivoUiState.isFormValid(),
@@ -222,7 +224,7 @@ fun DetalhesObjetivoScreen(
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedButton(
                     onClick = {
-                        onUiStateChange(updateObjetivoUiState.copy(modoAtivo = ModoAtivo.RESGATAR))
+                        onAlternarModoAtivo(ModoAtivo.RESGATAR)
                     },
                     modifier = Modifier
                         .weight(1f)
@@ -232,9 +234,7 @@ fun DetalhesObjetivoScreen(
                 }
 
                 Button(
-                    onClick = {
-                        onUiStateChange(updateObjetivoUiState.copy(modoAtivo = ModoAtivo.GUARDAR))
-                    },
+                    onClick = { onAlternarModoAtivo(ModoAtivo.GUARDAR) },
                     modifier = Modifier
                         .weight(1f)
                         .padding(bottom = 16.dp)
@@ -253,10 +253,13 @@ private fun DetalhesObjetivoScreenPreview() {
         DetalhesObjetivoScreen(
             detalhesObjetivoUiState = DetalhesObjetivoUiState(descricao = "Casa própria"),
             updateObjetivoUiState = UpdateObjetivoUiState(),
+            modoAtivo = ModoAtivo.INVISIBLE,
+            onAlternarModoAtivo = {},
             onUiStateChange = {},
             onNavigateUp = {},
             onResgatarClick = {},
             onGuardarClick = {},
+            onResetState = {},
         )
     }
 }

--- a/app/src/main/java/com/neuralnet/maisfinancas/ui/screens/objetivos/detalhes/UpdateObjetivoUiState.kt
+++ b/app/src/main/java/com/neuralnet/maisfinancas/ui/screens/objetivos/detalhes/UpdateObjetivoUiState.kt
@@ -6,7 +6,6 @@ import java.math.BigDecimal
 data class UpdateObjetivoUiState(
     val valor: String = "",
     val saldo: BigDecimal = BigDecimal.ZERO,
-    val modoAtivo: ModoAtivo = ModoAtivo.INVISIBLE,
     val valorErrorMessage: FieldValidationError? = null,
 ) {
     fun isFormValid() = valor.toDoubleOrNull() != null &&


### PR DESCRIPTION
fixes #4 

## Contexto

Ao digitar algum valor, o ViewModel, responsável por atualizar o estado, lançava uma nova corrotina para digito inserido na caixa de entrada a fim de atualizar o modo de alteração do objetivo (guardar ou resgatar) e calcular o saldo, sendo o saldo da conta no modo guardar ou valor depositado no objetivo, o que levava a inconsitências ao digitar rapidamente na caixa de entrada.

## Solução
Foi criado um novo atributo de estado para o modo que, quando selecionado o modo de alteração, realiza o cálculo apenas uma vez, deixando a função de atualização do estado para refletir o valor inserido na caixa de texto.
